### PR TITLE
Allow on click event to fire for KEYCODE_ENTER.

### DIFF
--- a/lib/src/main/java/net/ganin/darv/DpadAwareRecyclerView.java
+++ b/lib/src/main/java/net/ganin/darv/DpadAwareRecyclerView.java
@@ -755,12 +755,17 @@ public class DpadAwareRecyclerView extends RecyclerView implements
         if (focusedChild != null
                 && mOnItemClickListener != null
                 && event.getAction() == KeyEvent.ACTION_DOWN
-                && event.getKeyCode() == KeyEvent.KEYCODE_DPAD_CENTER
+                && isClickEvent(event)
                 && event.getRepeatCount() == 0) {
             fireOnItemClickEvent(focusedChild);
         }
 
         return consumed;
+    }
+
+    private boolean isClickEvent(@NonNull KeyEvent event) {
+        int keyCode = event.getKeyCode();
+        return keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyCode == KeyEvent.KEYCODE_ENTER;
     }
 
     @Override


### PR DESCRIPTION
Many devices for Android TV, Fire TV, and 3rd party remotes, fire KEYCODE_ENTER for onClickEvents.  This change allows DPAD_CENTER as well as KEYCODE_ENTER to fire the onClick event.
